### PR TITLE
Fix ISBN extraction logic

### DIFF
--- a/class.dkMARC.php
+++ b/class.dkMARC.php
@@ -164,7 +164,8 @@ class dkMARC{
 				$ret = $MARC[$i][2][1];
 				$pat = array('/.*([0-9]{13}).*/', '/.*([0-9]{9}[0-9xX]{1}).*/i', '/(.*)\([^\)]*\)(.*)/', '/[a-z]* :/');
 				$repl = array('$1','$1','$1$2','');
-				$ret = preg_replace($pat,'$1',$ret);
+                               // Apply each cleanup pattern in sequence to extract a clean ISBN
+                               $ret = preg_replace($pat, $repl, $ret);
 				if(!preg_match('/^[0-9]{9}/',$ret)){
 					$ret = 'null';
 				}


### PR DESCRIPTION
## Summary
- ensure ISBN cleanup applies intended replacement patterns

## Testing
- `php -l class.dkMARC.php`
- `php -r 'include "class.dkMARC.php"; $raw="020    \$a9780140449136 (pbk.) and more\n"; $dkmarc=new dkMARC($raw); $ref=new ReflectionClass($dkmarc); $m=$ref->getMethod("getISBN"); $m->setAccessible(true); ob_start(); $v=$m->invoke($dkmarc); ob_end_clean(); echo $v;'`


------
https://chatgpt.com/codex/tasks/task_e_689b0b4f9ef08328b8be1f2cf88eab80